### PR TITLE
[MON] Metrics - Add number of RPC calls per method

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,3 +19,5 @@ The user needs to specify at least one key, however, they don't need to specify 
 * `ORCH` or `OC`: Orchestration/CI related
 * `MNR`: Minor edit; usually used for uncategorized changes
 * `NA`: Not applicable
+* `MON`: Monitoring
+* `TSK`: Task

--- a/go/pkg/grpcmetrics/grpcmetrics.go
+++ b/go/pkg/grpcmetrics/grpcmetrics.go
@@ -12,6 +12,7 @@ import "github.com/prometheus/client_golang/prometheus"
 
 var (
 	// RPC Stats
+	MethodCalls  *prometheus.CounterVec
 	PayloadBytes *prometheus.SummaryVec
 	HeaderBytes  *prometheus.SummaryVec
 	TrailerBytes *prometheus.SummaryVec
@@ -39,6 +40,18 @@ func init() {
 // Initialize all supported the metrics
 func initializeMetrics(namespace string) {
 	// Create the required metrics
+
+	// Counters - RPC
+	MethodCalls = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "rpc_calls_total",
+			Help:      "The total number of remote procedure calls",
+		},
+		[]string{"method"},
+	)
+
+	// Summary - RPC
 	PayloadBytes = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace:  namespace,
@@ -73,7 +86,7 @@ func initializeMetrics(namespace string) {
 		// direction can be in our out, compression is generally 'compressed' or 'uncompressed'
 	)
 
-	// Gauges
+	// Gauges - Conn
 	ConnectionsActive = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: namespace,
@@ -83,7 +96,7 @@ func initializeMetrics(namespace string) {
 		[]string{"client"},
 	)
 
-	// Vectors
+	// Counters - Conn
 	ConnectionsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
@@ -97,10 +110,14 @@ func initializeMetrics(namespace string) {
 
 // Register the relavant metrics
 func registerMetrics() {
+
+	// RPC
+	prometheus.MustRegister(MethodCalls)
 	prometheus.MustRegister(PayloadBytes)
 	prometheus.MustRegister(HeaderBytes)
 	prometheus.MustRegister(TrailerBytes)
 
+	// Conn
 	prometheus.MustRegister(ConnectionsActive)
 	prometheus.MustRegister(ConnectionsTotal)
 

--- a/go/pkg/serverstats/serverstats.go
+++ b/go/pkg/serverstats/serverstats.go
@@ -49,7 +49,8 @@ func (g GRPCStats) HandleRPC(ctx context.Context, rpcStats stats.RPCStats) {
 	case *stats.OutPayload:
 		grpcmetrics.PayloadBytes.WithLabelValues(methodName, "out", "compressed", strconv.FormatBool(stat.Client)).Observe(float64(stat.WireLength))
 		grpcmetrics.PayloadBytes.WithLabelValues(methodName, "out", "uncompressed", strconv.FormatBool(stat.Client)).Observe(float64(stat.Length))
-	case *stats.InHeader: // These metrics are not very beneficial
+	case *stats.InHeader:
+		grpcmetrics.MethodCalls.WithLabelValues(stat.FullMethod).Inc()
 		grpcmetrics.HeaderBytes.WithLabelValues(stat.FullMethod, "in", strconv.FormatBool(stat.Client)).Observe(float64(stat.WireLength))
 	case *stats.OutTrailer:
 		grpcmetrics.TrailerBytes.WithLabelValues(method, "out", strconv.FormatBool(stat.Client)).Observe(float64(stat.WireLength))


### PR DESCRIPTION
### Changes
* [MON] Metrics - Add number of RPC calls per method
* [DOC] Update PR Template

### Testing
* [NA] Not Applicable

### Keys
Each commit (and/or a pull request) must have at least one (or more keys) to identify the nature of the commit. More than one keys can be used with a `-` in between.

The user needs to specify at least one key, however, they don't need to specify all applicable keys. This list of keys is not exhaustive and is expected to grow.

* `UTST` or `UT`: Untested; code is currently untested.
* `BCKUP` or `BK`: Code back up; this is generally developement-in-progress.
* `DRFT`: Draft; usually for pull requests
* `TST`: Test updates
* `DOC` or `DC`: Documentation/Readme update
* `CMPLT` or `CMP`: Feature complete
* `ORCH` or `OC`: Orchestration/CI related
* `MNR`: Minor edit; usually used for uncategorized changes
* `NA`: Not applicable
